### PR TITLE
fix(publisher): lazily manage the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ func main() {
 
 ## Publishing messages to a RabbitMQ exchange (advanced)
 
-In the simple publishing mechanism, tacle will open and close a connection
+In the simple publishing mechanism, tackle will open and close a connection
 every time it sends a message. This is fine for sending one or two messages,
 however, if you plan to publish large batches of messages, it will be more
 efficient to create a dedicated publisher that keeps the connection open
@@ -58,17 +58,16 @@ func main() {
   err := publisher.Connect()
   defer publisher.Close()
   if err != nil {
-    log.Info("failed to connect to rabbit mq server %v", err)
+    log.Info("failed to connect to rabbitmq server %v", err)
   }
 
   publishParams := tackle.PublishParams{
     Body:       []byte(`{"user_id": "123"}`),
     RoutingKey: "user-created",
     Exchange:   "user-exchange",
-    AmqpURL:    "guest@localhost:5467",
   }
 
-  err := publish.Publish(&publishParams)
+  err := publisher.PublishWithContext(context.Background(), &publishParams)
   if err != nil {
     log.Info("something went wrong while publishing %v", err)
   }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ however, if you plan to publish large batches of messages, it will be more
 efficient to create a dedicated publisher that keeps the connection open
 for a longer duration.
 
+`tackle.NewPublisher` creates a publisher that will lazily create the connection,
+re-connecting if the current connection is closed for some reason.
+
 ``` golang
 package main
 
@@ -54,12 +57,7 @@ import (
 
 func main() {
   publisher := tackle.NewPublisher("guest@localhost:5467")
-
-  err := publisher.Connect()
   defer publisher.Close()
-  if err != nil {
-    log.Info("failed to connect to rabbitmq server %v", err)
-  }
 
   publishParams := tackle.PublishParams{
     Body:       []byte(`{"user_id": "123"}`),

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -71,7 +71,7 @@ func TestProcessorRanOnceAndPublishWork(t *testing.T) {
 	err := PublishMessage(&params)
 	assert.Nil(t, err)
 
-	assert.Eventually(t, func() bool { return 1 == counter.count }, time.Second, 100*time.Millisecond)
+	assert.Eventually(t, func() bool { return counter.count == 1 }, time.Second, 100*time.Millisecond)
 	consumer.Stop()
 }
 

--- a/publisher.go
+++ b/publisher.go
@@ -85,6 +85,7 @@ func (p *Publisher) ExchangeDeclare(exchange string) error {
 		return err
 	}
 
+	defer channel.Close()
 	return channel.ExchangeDeclare(exchange, "direct", Durable, AutoDeleted, Internal, NoWait, nil)
 }
 

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,0 +1,64 @@
+package tackle
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test__Publisher(t *testing.T) {
+	p, err := NewPublisher(options.URL)
+	require.NoError(t, err)
+
+	counter := &struct {
+		count int
+	}{}
+
+	consumer := NewConsumer()
+	go func() {
+		err := consumer.Start(&options, func(delivery Delivery) error {
+			counter.count++
+			return nil
+		})
+		require.Nil(t, err)
+	}()
+
+	require.Eventually(t, func() bool { return consumer.State == StateListening }, time.Second, 100*time.Millisecond)
+
+	t.Run("publish works", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			mi := i
+			go func() {
+				require.NoError(t, p.Publish(&PublishParams{
+					Body:       []byte(fmt.Sprintf(`"{%d}"`, mi)),
+					Exchange:   options.RemoteExchange,
+					RoutingKey: options.RoutingKey,
+				}))
+			}()
+		}
+
+		require.Eventually(t, func() bool { return counter.count == 10 }, 2*time.Second, 100*time.Millisecond)
+		require.True(t, false)
+	})
+
+	t.Run("publish reconnects if connection is closed", func(t *testing.T) {
+		counter.count = 0
+		require.NoError(t, p.connection.Close())
+
+		for i := 0; i < 10; i++ {
+			mi := i
+			go func() {
+				require.NoError(t, p.Publish(&PublishParams{
+					Body:       []byte(fmt.Sprintf(`"{"id": %d}"`, mi)),
+					Exchange:   options.RemoteExchange,
+					RoutingKey: options.RoutingKey,
+				}))
+			}()
+		}
+
+		require.Eventually(t, func() bool { return counter.count == 10 }, 5*time.Second, 500*time.Millisecond)
+		require.True(t, false)
+	})
+}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,38 +1,28 @@
 package tackle
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	rabbit "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/require"
 )
 
 func Test__Publisher(t *testing.T) {
-	p, err := NewPublisher(options.URL)
-	require.NoError(t, err)
-
 	counter := &struct {
 		count int
 	}{}
 
-	consumer := NewConsumer()
-	go func() {
-		err := consumer.Start(&options, func(delivery Delivery) error {
-			counter.count++
-			return nil
-		})
-		require.Nil(t, err)
-	}()
-
-	require.Eventually(t, func() bool { return consumer.State == StateListening }, time.Second, 100*time.Millisecond)
+	p, _ := setup(t, counter, nil)
 
 	t.Run("publish works", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
-			mi := i
 			go func() {
 				require.NoError(t, p.Publish(&PublishParams{
-					Body:       []byte(fmt.Sprintf(`"{%d}"`, mi)),
+					Body:       []byte(`"{}"`),
 					Exchange:   options.RemoteExchange,
 					RoutingKey: options.RoutingKey,
 				}))
@@ -47,10 +37,9 @@ func Test__Publisher(t *testing.T) {
 		require.NoError(t, p.connection.Close())
 
 		for i := 0; i < 10; i++ {
-			mi := i
 			go func() {
 				require.NoError(t, p.Publish(&PublishParams{
-					Body:       []byte(fmt.Sprintf(`"{"id": %d}"`, mi)),
+					Body:       []byte(`"{}"`),
 					Exchange:   options.RemoteExchange,
 					RoutingKey: options.RoutingKey,
 				}))
@@ -59,4 +48,61 @@ func Test__Publisher(t *testing.T) {
 
 		require.Eventually(t, func() bool { return counter.count == 10 }, 5*time.Second, 500*time.Millisecond)
 	})
+}
+
+func Test__PublishDoesNotRetryForever(t *testing.T) {
+	counter := &struct {
+		count int
+	}{}
+
+	p, _ := setup(t, counter, func() (*rabbit.Connection, error) {
+		return nil, fmt.Errorf("failed to connect")
+	})
+
+	errs := []error{}
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 10; i++ {
+		mi := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelFunc()
+
+			err := p.PublishWithContext(ctx, &PublishParams{
+				Body:       []byte(fmt.Sprintf(`"%d"`, mi)),
+				Exchange:   options.RemoteExchange,
+				RoutingKey: options.RoutingKey,
+			})
+
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	for _, e := range errs {
+		require.ErrorContains(t, e, "context deadline exceeded")
+	}
+}
+
+func setup(t *testing.T, counter *struct{ count int }, connectFunc func() (*rabbit.Connection, error)) (*Publisher, *Consumer) {
+	p, err := NewPublisher(options.URL, connectFunc)
+	require.NoError(t, err)
+
+	consumer := NewConsumer()
+	go func() {
+		err := consumer.Start(&options, func(delivery Delivery) error {
+			counter.count++
+			return nil
+		})
+		require.Nil(t, err)
+	}()
+
+	require.Eventually(t, func() bool { return consumer.State == StateListening }, time.Second, 100*time.Millisecond)
+	return p, consumer
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -40,7 +40,6 @@ func Test__Publisher(t *testing.T) {
 		}
 
 		require.Eventually(t, func() bool { return counter.count == 10 }, 2*time.Second, 100*time.Millisecond)
-		require.True(t, false)
 	})
 
 	t.Run("publish reconnects if connection is closed", func(t *testing.T) {
@@ -59,6 +58,5 @@ func Test__Publisher(t *testing.T) {
 		}
 
 		require.Eventually(t, func() bool { return counter.count == 10 }, 5*time.Second, 500*time.Millisecond)
-		require.True(t, false)
 	})
 }


### PR DESCRIPTION
### Motivation

Currently, `tackle.Publisher` will not reconnect if the current connection is closed. This pushes the need for connection handling to the user of the library, which is not good.

### Solution

This pull request fixes that by turning the publisher into a lazy connector. The connection will be created when publishing a message, if a connection hasn't been established yet. The publisher will also attempt to re-create a connection if the current connection was closed.

### Other changes

- A new `PublishWithContext` method was added to allow callers to not wait forever when connections can't be established or messages can't be published.
- `NewPublisher` now requires a `PublisherOptions` object, allowing the user to specify the connection name and timeout.
