### PR TITLE
feat(consumer): add OnDeadFunc hook

### DIFF
--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	RoutingKey     string
 	RetryDelay     int32
 	RetryLimit     int32
+	OnDeadFunc     func(Delivery)
 }
 
 func (o *Options) GetServiceExchangeName() string {


### PR DESCRIPTION
Sometimes, custom code needs to run when the consumer gives up on processing the message, and sends it to the dead queue. Here's [an example](https://github.com/renderedtext/alles/pull/907/files#diff-7d475fdeb772081c6ee0c9880e13bcacb934f655af40e78e5fce84cb19ca3752R36) of that usage.

To support that, we add a `OnDeadFunc` hook to the options that can be passed into the consumer. If that hook is specified, it will be called when the message is sent to the dead queue.